### PR TITLE
Add spring-boot-maven-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ export WON_NODE_URI="https://hackathonnode.matchat.org/won"
 mvn clean package
 java -jar target/bot.jar
 ```
+When bot startup is complete, you should see an output similar to this:
+```
+[...]
+2019-12-08 18:45:59.888  INFO 2056 --- [taskScheduler-6] w.b.f.eventbot.action.impl.LogAction     : Successfully registered as Matcher
+2019-12-08 18:46:03.523  INFO 2056 --- [taskScheduler-5] w.b.f.e.s.ServiceAtomBehaviour           : #####################################################################################
+2019-12-08 18:46:03.523  INFO 2056 --- [taskScheduler-5] w.b.f.e.s.ServiceAtomBehaviour           : BotServiceAtom creation successful, new atom URI is https://hackathonnode.matchat.org/won/resource/atom/wpt10wokd33ert687dqw
+2019-12-08 18:46:03.523  INFO 2056 --- [taskScheduler-5] w.b.f.e.s.ServiceAtomBehaviour           : #####################################################################################
+```
+If this method does not work (it does not for some setups), try the following:
+
+```
+cd bot-skeleton
+export WON_CONFIG_DIR="$(pwd)/conf"
+export WON_NODE_URI="https://hackathonnode.matchat.org/won"
+mvn spring-boot:run
+```
+
 Now go to [What's new](https://hackathon.matchat.org/owner/#!/overview) to find your bot, connect and [create an atom](https://hackathon.matchat.org/owner/#!/create) to see the bot in action.
 
 ### In Intellij Idea

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,21 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+			<plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.1.7.RELEASE</version>
+                <configuration>
+                    <mainClass>won.bot.skeleton.SkeletonBotApp</mainClass>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>


### PR DESCRIPTION
Add the spring-boot-maven-plugin for setups in which the shaded jar does not work because the BouncyCastle provider's signatures cannot be verified.

* Updates the pom.xml
* Adds the usage info to the README.md